### PR TITLE
スキル表示の改善とQiitaリンク追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,17 +84,86 @@
                     </div>
                     <div class="skills parallax-element">
                         <h3>Technical Skills</h3>
-                        <div class="skill-tags">
-                            <span class="skill-tag">Python</span>
-                            <span class="skill-tag">TensorFlow</span>
-                            <span class="skill-tag">PyTorch</span>
-                            <span class="skill-tag">Scikit-learn</span>
-                            <span class="skill-tag">GCP</span>
-                            <span class="skill-tag">Docker</span>
-                            <span class="skill-tag">Deep Learning</span>
-                            <span class="skill-tag">Computer Vision</span>
-                            <span class="skill-tag">Recommendation Systems</span>
-                            <span class="skill-tag">A/B Testing</span>
+                        <div class="skills-grid">
+                            <div class="skill-category">
+                                <h4>プログラミング言語</h4>
+                                <div class="skill-item">
+                                    <div class="skill-name">Python</div>
+                                    <div class="skill-level">
+                                        <div class="skill-bar" data-level="90"></div>
+                                        <span class="skill-years">4年</span>
+                                    </div>
+                                </div>
+                                <div class="skill-item">
+                                    <div class="skill-name">SQL</div>
+                                    <div class="skill-level">
+                                        <div class="skill-bar" data-level="75"></div>
+                                        <span class="skill-years">3年</span>
+                                    </div>
+                                </div>
+                                <div class="skill-item">
+                                    <div class="skill-name">JavaScript</div>
+                                    <div class="skill-level">
+                                        <div class="skill-bar" data-level="60"></div>
+                                        <span class="skill-years">2年</span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="skill-category">
+                                <h4>機械学習・AI</h4>
+                                <div class="skill-item">
+                                    <div class="skill-name">TensorFlow</div>
+                                    <div class="skill-level">
+                                        <div class="skill-bar" data-level="85"></div>
+                                        <span class="skill-years">3年</span>
+                                    </div>
+                                </div>
+                                <div class="skill-item">
+                                    <div class="skill-name">PyTorch</div>
+                                    <div class="skill-level">
+                                        <div class="skill-bar" data-level="80"></div>
+                                        <span class="skill-years">3年</span>
+                                    </div>
+                                </div>
+                                <div class="skill-item">
+                                    <div class="skill-name">Scikit-learn</div>
+                                    <div class="skill-level">
+                                        <div class="skill-bar" data-level="85"></div>
+                                        <span class="skill-years">4年</span>
+                                    </div>
+                                </div>
+                                <div class="skill-item">
+                                    <div class="skill-name">推薦システム</div>
+                                    <div class="skill-level">
+                                        <div class="skill-bar" data-level="75"></div>
+                                        <span class="skill-years">1年</span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="skill-category">
+                                <h4>インフラ・ツール</h4>
+                                <div class="skill-item">
+                                    <div class="skill-name">GCP</div>
+                                    <div class="skill-level">
+                                        <div class="skill-bar" data-level="70"></div>
+                                        <span class="skill-years">2年</span>
+                                    </div>
+                                </div>
+                                <div class="skill-item">
+                                    <div class="skill-name">Docker</div>
+                                    <div class="skill-level">
+                                        <div class="skill-bar" data-level="65"></div>
+                                        <span class="skill-years">2年</span>
+                                    </div>
+                                </div>
+                                <div class="skill-item">
+                                    <div class="skill-name">Git</div>
+                                    <div class="skill-level">
+                                        <div class="skill-bar" data-level="80"></div>
+                                        <span class="skill-years">4年</span>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -172,6 +241,10 @@
                         <a href="https://github.com/rabbit-313" class="contact-link">
                             <i class="fab fa-github"></i>
                             GitHub
+                        </a>
+                        <a href="https://qiita.com/rabbit-313" class="contact-link">
+                            <i class="fas fa-pen-nib"></i>
+                            Qiita
                         </a>
                         <a href="https://x.com/rabbit_x86" class="contact-link">
                             <i class="fab fa-twitter"></i>

--- a/style.css
+++ b/style.css
@@ -430,6 +430,98 @@ body {
     font-size: 1.3rem;
 }
 
+.skills-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+    margin-top: 1.5rem;
+}
+
+.skill-category {
+    background: var(--card-bg);
+    padding: 1.5rem;
+    border-radius: 12px;
+    border: 1px solid var(--border-color);
+}
+
+.skill-category h4 {
+    color: var(--text-primary);
+    font-size: 1.1rem;
+    margin-bottom: 1rem;
+    border-bottom: 2px solid var(--accent-primary);
+    padding-bottom: 0.5rem;
+}
+
+.skill-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    padding: 0.5rem 0;
+}
+
+.skill-item:last-child {
+    margin-bottom: 0;
+}
+
+.skill-name {
+    color: var(--text-secondary);
+    font-weight: 500;
+    min-width: 100px;
+    flex-shrink: 0;
+}
+
+.skill-level {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex: 1;
+    margin-left: 1rem;
+}
+
+.skill-bar {
+    flex: 1;
+    height: 8px;
+    background: var(--bg-tertiary);
+    border-radius: 4px;
+    position: relative;
+    overflow: hidden;
+}
+
+.skill-bar::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background: var(--gradient-tertiary);
+    border-radius: 4px;
+    transition: width 1s ease-out;
+    width: 0;
+}
+
+.skill-bar[data-level="90"]::before { width: 90%; }
+.skill-bar[data-level="85"]::before { width: 85%; }
+.skill-bar[data-level="80"]::before { width: 80%; }
+.skill-bar[data-level="75"]::before { width: 75%; }
+.skill-bar[data-level="70"]::before { width: 70%; }
+.skill-bar[data-level="65"]::before { width: 65%; }
+.skill-bar[data-level="60"]::before { width: 60%; }
+
+.skill-years {
+    color: var(--accent-primary);
+    font-size: 0.8rem;
+    font-weight: 600;
+    min-width: 30px;
+    text-align: center;
+}
+
+.skill-category:hover {
+    transform: translateY(-2px);
+    transition: transform 0.3s ease;
+}
+
+/* Legacy skill tags (for backward compatibility) */
 .skill-tags {
     display: flex;
     flex-wrap: wrap;
@@ -662,6 +754,11 @@ footer p {
     .projects-grid {
         grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     }
+    
+    .skills-grid {
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 1.5rem;
+    }
 }
 
 @media (max-width: 768px) {
@@ -791,6 +888,30 @@ footer p {
     .section-title {
         font-size: 1.8rem;
         margin-bottom: 2rem;
+    }
+    
+    .skills-grid {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+    }
+    
+    .skill-category {
+        padding: 1.2rem;
+    }
+    
+    .skill-item {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.5rem;
+    }
+    
+    .skill-level {
+        margin-left: 0;
+    }
+    
+    .skill-name {
+        min-width: auto;
+        margin-bottom: 0.2rem;
     }
     
     .skill-tags {


### PR DESCRIPTION
## 概要
スキルセクションの表示方法を改善し、より詳細で視覚的に分かりやすい形式に変更しました。また、Qiitaリンクをコンタクトセクションに追加しました。

## 主な変更点
- **スキル表示の刷新**: タグ形式からプログレスバー+経験年数表示に変更
- **カテゴリ分類**: プログラミング言語、機械学習・AI、インフラ・ツールの3カテゴリに整理
- **Qiitaリンク追加**: コンタクトセクションにQiita（@rabbit-313）のリンクを追加
- **レスポンシブ対応**: モバイル・タブレット向けの表示最適化

## 技術的改善
- CSS Grid レイアウトによる柔軟なカテゴリ表示
- アニメーション付きプログレスバーで習熟度を視覚化
- データ属性を使用した動的なプログレスバー制御
- モバイルファーストなレスポンシブデザイン

## スキル評価基準
- **経験年数**: 実際の使用期間に基づく
- **習熟度**: 実務・研究での活用レベルを数値化（60-90%）
- **分類**: 技術領域別に整理し、専門性を明確化

🤖 Generated with [Claude Code](https://claude.ai/code)