### PR TITLE
年数に応じたスキルレベルの適正化

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
                                 <div class="skill-item">
                                     <div class="skill-name">Python</div>
                                     <div class="skill-level">
-                                        <div class="skill-bar" data-level="90">
+                                        <div class="skill-bar" data-level="85">
                                             <div class="skill-bar-fill"></div>
                                         </div>
                                         <span class="skill-years">4年</span>
@@ -99,7 +99,7 @@
                                 <div class="skill-item">
                                     <div class="skill-name">SQL</div>
                                     <div class="skill-level">
-                                        <div class="skill-bar" data-level="75">
+                                        <div class="skill-bar" data-level="65">
                                             <div class="skill-bar-fill"></div>
                                         </div>
                                         <span class="skill-years">3年</span>
@@ -108,7 +108,7 @@
                                 <div class="skill-item">
                                     <div class="skill-name">JavaScript</div>
                                     <div class="skill-level">
-                                        <div class="skill-bar" data-level="60">
+                                        <div class="skill-bar" data-level="55">
                                             <div class="skill-bar-fill"></div>
                                         </div>
                                         <span class="skill-years">2年</span>
@@ -120,7 +120,7 @@
                                 <div class="skill-item">
                                     <div class="skill-name">TensorFlow</div>
                                     <div class="skill-level">
-                                        <div class="skill-bar" data-level="85">
+                                        <div class="skill-bar" data-level="75">
                                             <div class="skill-bar-fill"></div>
                                         </div>
                                         <span class="skill-years">3年</span>
@@ -129,7 +129,7 @@
                                 <div class="skill-item">
                                     <div class="skill-name">PyTorch</div>
                                     <div class="skill-level">
-                                        <div class="skill-bar" data-level="80">
+                                        <div class="skill-bar" data-level="70">
                                             <div class="skill-bar-fill"></div>
                                         </div>
                                         <span class="skill-years">3年</span>
@@ -138,7 +138,7 @@
                                 <div class="skill-item">
                                     <div class="skill-name">Scikit-learn</div>
                                     <div class="skill-level">
-                                        <div class="skill-bar" data-level="85">
+                                        <div class="skill-bar" data-level="80">
                                             <div class="skill-bar-fill"></div>
                                         </div>
                                         <span class="skill-years">4年</span>
@@ -147,7 +147,7 @@
                                 <div class="skill-item">
                                     <div class="skill-name">推薦システム</div>
                                     <div class="skill-level">
-                                        <div class="skill-bar" data-level="75">
+                                        <div class="skill-bar" data-level="45">
                                             <div class="skill-bar-fill"></div>
                                         </div>
                                         <span class="skill-years">1年</span>
@@ -159,7 +159,7 @@
                                 <div class="skill-item">
                                     <div class="skill-name">GCP</div>
                                     <div class="skill-level">
-                                        <div class="skill-bar" data-level="70">
+                                        <div class="skill-bar" data-level="60">
                                             <div class="skill-bar-fill"></div>
                                         </div>
                                         <span class="skill-years">2年</span>
@@ -168,7 +168,7 @@
                                 <div class="skill-item">
                                     <div class="skill-name">Docker</div>
                                     <div class="skill-level">
-                                        <div class="skill-bar" data-level="65">
+                                        <div class="skill-bar" data-level="55">
                                             <div class="skill-bar-fill"></div>
                                         </div>
                                         <span class="skill-years">2年</span>
@@ -177,7 +177,7 @@
                                 <div class="skill-item">
                                     <div class="skill-name">Git</div>
                                     <div class="skill-level">
-                                        <div class="skill-bar" data-level="80">
+                                        <div class="skill-bar" data-level="75">
                                             <div class="skill-bar-fill"></div>
                                         </div>
                                         <span class="skill-years">4年</span>

--- a/style.css
+++ b/style.css
@@ -496,6 +496,24 @@ body {
     width: 0%;
 }
 
+/* Color variations based on skill level */
+.skill-bar[data-level="45"] .skill-bar-fill,
+.skill-bar[data-level="55"] .skill-bar-fill {
+    background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%); /* Beginner - Pink */
+}
+
+.skill-bar[data-level="60"] .skill-bar-fill,
+.skill-bar[data-level="65"] .skill-bar-fill,
+.skill-bar[data-level="70"] .skill-bar-fill {
+    background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%); /* Intermediate - Cyan-Pink */
+}
+
+.skill-bar[data-level="75"] .skill-bar-fill,
+.skill-bar[data-level="80"] .skill-bar-fill,
+.skill-bar[data-level="85"] .skill-bar-fill {
+    background: var(--gradient-tertiary); /* Advanced - Original gradient */
+}
+
 .skill-years {
     color: var(--accent-primary);
     font-size: 0.8rem;


### PR DESCRIPTION
## 概要
スキルバーの表示レベルを実際の経験年数に基づいて調整し、新卒エンジニアとして現実的で適切な評価に修正しました。

## 主な変更点

### スキルレベル調整
| スキル | 経験年数 | 変更前 | 変更後 | 理由 |
|--------|----------|--------|--------|------|
| Python | 4年 | 90% | 85% | より現実的なレベル |
| SQL | 3年 | 75% | 65% | 3年経験として適正 |
| JavaScript | 2年 | 60% | 55% | 2年経験として適正 |
| TensorFlow | 3年 | 85% | 75% | 研究メインのため調整 |
| PyTorch | 3年 | 80% | 70% | 研究メインのため調整 |
| Scikit-learn | 4年 | 85% | 80% | 長期経験を反映 |
| 推薦システム | 1年 | 75% | 45% | 1年経験として適正 |
| GCP | 2年 | 70% | 60% | 2年経験として適正 |
| Docker | 2年 | 65% | 55% | 2年経験として適正 |
| Git | 4年 | 80% | 75% | 大学時代から使用 |

### 視覚的改善
- **初級レベル (45-55%)**: ピンクグラデーション
- **中級レベル (60-70%)**: シアン-ピンクグラデーション  
- **上級レベル (75-85%)**: オリジナルテーマカラー

### スキルレベル判定基準
- **45-55%**: 基礎レベル（1-2年）
- **60-70%**: 実用レベル（2-3年）
- **75-85%**: 熟練レベル（3年以上）

## 技術的改善
- レベル別の色分けで直感的な理解向上
- 経験年数とスキルレベルの整合性確保
- 新卒エンジニアとして誠実で現実的な自己評価

## 動作確認
- [ ] ローカル環境での表示確認
- [ ] レスポンシブデザイン確認
- [ ] アニメーション動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)